### PR TITLE
Fix default stroke size

### DIFF
--- a/robotiq_2f_gripper_control/src/robotiq_2f_gripper_control/robotiq_2f_gripper_driver.py
+++ b/robotiq_2f_gripper_control/src/robotiq_2f_gripper_control/robotiq_2f_gripper_driver.py
@@ -431,7 +431,7 @@ class Robotiq2FingerSimulatedGripperDriver:
         _current_joint_pos: [radians] Position of the simulated joint in radians.
         _current_goal: Instance of `RobotiqGripperCommand` message holding the latest user command.
     """
-    def __init__(self, stroke=0.85, joint_name='finger_joint'):
+    def __init__(self, stroke=0.085, joint_name='finger_joint'):
         self._stroke = stroke
         self._joint_name = joint_name
         self._current_joint_pos = 0.0                                 


### PR DESCRIPTION
Docstring indicates stroke should be `0.085` or `0.140`, but default argument (L484) is `0.85`. Fixed to `0.085`