### PR TITLE
Fix _update_gripper_joint_state stroke checks

### DIFF
--- a/robotiq_2f_gripper_control/src/robotiq_2f_gripper_control/robotiq_2f_gripper_driver.py
+++ b/robotiq_2f_gripper_control/src/robotiq_2f_gripper_control/robotiq_2f_gripper_driver.py
@@ -200,7 +200,7 @@ class Robotiq2FingerGripperDriver:
         js.header.seq = self._seq
         js.name = [self._joint_name]
         max_joint_limit = 0.8
-        if( self._gripper.stroke == 140 ):
+        if( self._gripper.stroke == 0.140 ):
             max_joint_limit = 0.7
         pos = np.clip(max_joint_limit - ((max_joint_limit/self._gripper.stroke) * self._gripper.get_pos()), 0., max_joint_limit)
         js.position = [pos]


### PR DESCRIPTION
Previously, `max_joint_limit` was only set to `.7` if `self._gripper.stroke == 140`. However, this condition is never satisfied because `self._gripper.stroke` should never be 140 (but can be .140). Fixed to check whether `self._gripper.stroke == 0.140`